### PR TITLE
require tilt in lib/stitch_rails.rb

### DIFF
--- a/lib/stitch_rails.rb
+++ b/lib/stitch_rails.rb
@@ -1,3 +1,5 @@
+require 'tilt'
+
 module Stitch
   class StitchyCoffeeScriptTemplate < Tilt::Template
     self.default_mime_type = 'application/javascript'


### PR DESCRIPTION
In order for to get this gem to work, I had to `require 'tilt'` in `lib/stitch_rails.rb`.
