### PR TITLE
Fix gemspec to point to real files

### DIFF
--- a/stitch_rails.gemspec
+++ b/stitch_rails.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |s|
   s.email = "me@iany.me"
   s.extra_rdoc_files = [
     "LICENSE.txt",
-    "README.rdoc"
+    "README.md"
   ]
   s.files = [
     "Gemfile",
     "Gemfile.lock",
     "LICENSE.txt",
-    "README.rdoc",
+    "README.md",
     "Rakefile",
     "VERSION",
     "lib/assets/javascripts/stitch_rails.js.coffee",


### PR DESCRIPTION
Currently, the `.gemspec` still references `README.rdoc`, which has been changed to `README.md`.
